### PR TITLE
fix: install using lockfiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ async function run() {
     }
 
     const pkgManager = (await ioUtil.exists("./yarn.lock")) ? "yarn" : "npm";
+    const installCmd = pkgManager === 'yarn' ? 'install --frozen-lockfile' : 'ci'
     console.log(`Installing your site's dependencies using ${pkgManager}.`);
-    await exec.exec(`${pkgManager} install`);
+    await exec.exec(`${pkgManager} ${installCmd}`);
     console.log("Finished installing dependencies.");
 
     let buildArgs = core.getInput("build-args").trim();

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function run() {
     }
 
     const pkgManager = (await ioUtil.exists("./yarn.lock")) ? "yarn" : "npm";
-    const installCmd = pkgManager === 'yarn' ? 'install --frozen-lockfile' : 'ci'
+    const installCmd = pkgManager === "yarn" ? "install --frozen-lockfile" : "ci"
     console.log(`Installing your site's dependencies using ${pkgManager}.`);
     await exec.exec(`${pkgManager} ${installCmd}`);
     console.log("Finished installing dependencies.");


### PR DESCRIPTION
fixes #8 

This will detect yarn vs npm.  If yarn, it will execute `yarn install --frozen-lockfile`.  If npm, it will execute `npm ci`