### PR TITLE
docs: Update version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - uses: cmgriffing/scully-gh-pages-action@v9
+      - uses: cmgriffing/scully-gh-pages-action@v10
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
 ```
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: cmgriffing/scully-gh-pages-action@v9
+      - uses: cmgriffing/scully-gh-pages-action@v10
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
 ```


### PR DESCRIPTION
My [angular-scully-blog](https://github.com/SHANG-TING/angular-scully-blog) project, because of the use of v9, has been experiencing abnormal problems (for example: unable to obtain the scully version), until I found that there is a v10 version, the upgrade solves the problem, so I hope to update the file description. 