### PR TITLE
ci: update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install


### PR DESCRIPTION
- Update `actions/checkout` to `v3`
  - Breaking change: Use Node.js 16 internally
- Update `actions/setup-node` to `v3`
  - Breaking change: Switch internal Node.js fetching strategy
  - Breaking change: Use Node.js 16 internally